### PR TITLE
Fix of fresh install settings

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,8 +8,11 @@ import socket
 # or add the `decky-loader/plugin` path to `python.analysis.extraPaths` in `.vscode/settings.json`
 import decky_plugin
 
-script_dir = os.environ["DECKY_PLUGIN_DIR"]
-pidfile = os.environ["DECKY_PLUGIN_RUNTIME_DIR"] + "/decky-filebrowser.pid"
+settingsDir = decky_plugin.DECKY_PLUGIN_SETTINGS_DIR
+
+script_dir = decky_plugin.DECKY_PLUGIN_DIR
+pidfile = decky_plugin.DECKY_PLUGIN_RUNTIME_DIR + "/decky-filebrowser.pid"
+
 
 class Plugin:
     # A normal method. It can be called from JavaScript using call_plugin_function("method_1", argument1, argument2)
@@ -33,7 +36,7 @@ class Plugin:
             return False
 
     async def startFileBrowser( self, port = "8082" ):
-        command = script_dir + "/bin/filebrowser -p " + port + " -a 0.0.0.0 -r " + os.environ["DECKY_USER_HOME"]
+        command = script_dir + "/bin/filebrowser -p " + port + " -a 0.0.0.0 -r " + decky_plugin.DECKY_USER_HOME
         process = await asyncio.create_subprocess_shell(command, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
 
         with open(pidfile, "w") as file:

--- a/main.py
+++ b/main.py
@@ -8,8 +8,8 @@ import socket
 # or add the `decky-loader/plugin` path to `python.analysis.extraPaths` in `.vscode/settings.json`
 import decky_plugin
 
-script_dir = os.path.dirname(os.path.abspath(__file__))
-pidfile = script_dir + "/bin/filebrowser.pid"
+script_dir = os.environ["DECKY_PLUGIN_DIR"]
+pidfile = os.environ["DECKY_PLUGIN_RUNTIME_DIR"] + "/decky-filebrowser.pid"
 
 class Plugin:
     # A normal method. It can be called from JavaScript using call_plugin_function("method_1", argument1, argument2)
@@ -33,7 +33,7 @@ class Plugin:
             return False
 
     async def startFileBrowser( self, port = "8082" ):
-        command = script_dir + "/bin/filebrowser -p " + port + " -a 0.0.0.0 -r /home/deck"
+        command = script_dir + "/bin/filebrowser -p " + port + " -a 0.0.0.0 -r " + os.environ["DECKY_USER_HOME"]
         process = await asyncio.create_subprocess_shell(command, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
 
         with open(pidfile, "w") as file:

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "Decky FileBrowser",
   "author": "Heyde Moura",
-  "flags": ["_root"],
+  "flags": [],
   "publish": {
     "tags": [ "files", "server" ],
     "description": "Send and download files to your Steam Deck from a browser.",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -77,19 +77,27 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({serverAPI}) => {
         </ButtonItem>
       </PanelSectionRow>
 
-      <PanelSectionRow>
-        { processPID > 0 && serverStatus ?
-          <QRCodeSVG
-            value={ `http://${serverIP}:8082` }
-            size={256}
-          />
-          : (
-            <div style={{ display: "flex", justifyContent: "center" }}>
-              <img src={logo} />
-            </div>
-          )
-        }
-      </PanelSectionRow>
+      { processPID > 0 && serverStatus ? (
+        <>
+          <PanelSectionRow>
+            { `http://${serverIP}:8082` }
+          </PanelSectionRow>
+          <PanelSectionRow>
+              <QRCodeSVG
+                value={ `http://${serverIP}:8082` }
+                size={256}
+              />
+
+          </PanelSectionRow>
+        </>
+      ) : (
+        <PanelSectionRow>
+          <div style={{ display: "flex", justifyContent: "center" }}>
+            <img src={logo} />
+          </div>
+        </PanelSectionRow>
+        )
+      }
     </PanelSection>
   );
 };


### PR DESCRIPTION
Fixes some errors when doing a fresh install of the plugin.
I could not spot these at first since I was changing permissions on my `$HOME/homebrew` folder to copy files over ssh.

Now the plugin relies on decky's environment variables for common system paths referencing.