### PR TITLE
Feature: Adding the ability to change which port to start the server on

### DIFF
--- a/main.py
+++ b/main.py
@@ -40,8 +40,8 @@ class Plugin:
                 "port": settings.getSetting("port")
             }
 
-    async def startFileBrowser( self, port = "8082" ):
-        command = script_dir + "/bin/filebrowser -p " + port + " -a 0.0.0.0 -r " + decky_plugin.DECKY_USER_HOME
+    async def startFileBrowser( self, port = 8082 ):
+        command = script_dir + "/bin/filebrowser -p " + str(port) + " -a 0.0.0.0 -r " + decky_plugin.DECKY_USER_HOME
         process = await asyncio.create_subprocess_shell(command, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
 
         # Defines the received port as the port setting
@@ -67,6 +67,13 @@ class Plugin:
             os.remove(pidfile)
 
         return output_str
+
+    async def get_setting( self, key ):
+        return settings.getSetting( key );
+
+    async def save_user_settings( self, key: str, value ):
+        decky_plugin.logger.info("Changing settings - {}: {}".format( key, value ))
+        return settings.setSetting( key, value )
 
     # Asyncio-compatible long-running code, executed in a task when the plugin is loaded
     async def _main(self):

--- a/main.py
+++ b/main.py
@@ -3,6 +3,9 @@ import asyncio
 import subprocess
 import socket
 
+# Initialize decky-loader settings manager
+from settings import SettingsManager
+
 # The decky plugin module is located at decky-loader/plugin
 # For easy intellisense checkout the decky-loader code one directory up
 # or add the `decky-loader/plugin` path to `python.analysis.extraPaths` in `.vscode/settings.json`
@@ -13,12 +16,11 @@ settingsDir = decky_plugin.DECKY_PLUGIN_SETTINGS_DIR
 script_dir = decky_plugin.DECKY_PLUGIN_DIR
 pidfile = decky_plugin.DECKY_PLUGIN_RUNTIME_DIR + "/decky-filebrowser.pid"
 
+# Load user's settings
+settings = SettingsManager(name="settings", settings_directory=settingsDir)
+settings.read()
 
 class Plugin:
-    # A normal method. It can be called from JavaScript using call_plugin_function("method_1", argument1, argument2)
-    async def add(self, left, right):
-        return left + right
-
     async def getFileBrowserStatus( self ):
         if os.path.exists( pidfile ):
             with open( pidfile, "r" ) as file:
@@ -29,15 +31,21 @@ class Plugin:
 
             return {
                 "pid": pid_str,
-                "ipv4_address": ipv4_address
+                "ipv4_address": ipv4_address,
+                "port": settings.getSetting("port"),
             }
 
         else:
-            return False
+            return {
+                "port": settings.getSetting("port")
+            }
 
     async def startFileBrowser( self, port = "8082" ):
         command = script_dir + "/bin/filebrowser -p " + port + " -a 0.0.0.0 -r " + decky_plugin.DECKY_USER_HOME
         process = await asyncio.create_subprocess_shell(command, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+
+        # Defines the received port as the port setting
+        settings.setSetting("port", port)
 
         with open(pidfile, "w") as file:
             file.write(str(process.pid))

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,8 +15,6 @@ import Settings from './settings';
 import { AppContext, AppContextProvider } from './utils/app-context';
 import FileBrowserManager from './state/filebrowser-manager';
 
-import logo from "../assets/logo.png";
-
 const Content: VFC = () => {
   const [ isLoading, setIsLoading ] = useState( false );
   const [ serverStatus, setServerStatus ] = useState( false );
@@ -63,11 +61,6 @@ const Content: VFC = () => {
     }
   }
 
-  const handlePortChange = ( e ) => {
-    console.log(e.target);
-
-  }
-
   const handleGoToSettings = () => {
     Navigation.CloseSideMenus();
     Navigation.Navigate("/decky-filebrowser-settings")
@@ -85,58 +78,56 @@ const Content: VFC = () => {
   }, [] );
 
   return (
-    <PanelSection title={ isServerRunning ? "Server ON" : "Server OFF" }>
-      <PanelSectionRow>
-        <ButtonItem layout="below"
-          onClick={handleStartServer}
-          disabled={ isLoading }
-        >
-          { isServerRunning ? "Stop Server" : "Start Server" }
-        </ButtonItem>
-      </PanelSectionRow>
+    <>
+      <PanelSection title={ isServerRunning ? "Server ON" : "Server OFF" }>
+        <PanelSectionRow>
+          <ButtonItem layout="below"
+            onClick={handleStartServer}
+            disabled={ isLoading }
+          >
+            { isServerRunning ? "Stop Server" : "Start Server" }
+          </ButtonItem>
+        </PanelSectionRow>
 
-      { isServerRunning ? (
-        <>
-          <PanelSectionRow>
-            { `http://${serverIP}:${port}` }
-          </PanelSectionRow>
-          <PanelSectionRow>
-              <QRCodeSVG
-                value={ `http://${serverIP}:${port}` }
-                size={256}
-              />
+        { isServerRunning ? (
+          <>
+            <PanelSectionRow>
+              { `http://${serverIP}:${port}` }
+            </PanelSectionRow>
+            <PanelSectionRow>
+                <QRCodeSVG
+                  value={ `http://${serverIP}:${port}` }
+                  size={256}
+                />
 
-          </PanelSectionRow>
-        </>
-      ) : (
-        <>
-          <PanelSectionRow>
-            <ButtonItem
-              layout="below"
-              onClick={ handleGoToSettings }
-              disabled={ isLoading }
-            >
-              Go to Settings
-            </ButtonItem>
-          </PanelSectionRow>
-          <PanelSectionRow>
-            <TextField
-              label="Port"
-              description="Port to be used to connect"
-              mustBeNumeric
-              onChange={ handlePortChange }
-              value={ port }
-            />
-          </PanelSectionRow>
-          <PanelSectionRow>
-            <div style={{ display: "flex", justifyContent: "center" }}>
-              <img src={logo} />
-            </div>
-          </PanelSectionRow>
-        </>
-        )
-      }
-    </PanelSection>
+            </PanelSectionRow>
+          </>
+        ) : (
+          <>
+            <PanelSectionRow>
+              <ButtonItem
+                layout="below"
+                onClick={ handleGoToSettings }
+                disabled={ isLoading }
+              >
+                Go to Settings
+              </ButtonItem>
+            </PanelSectionRow>
+          </>
+          )
+        }
+      </PanelSection>
+      <PanelSection title={ "Current Settings" }>
+        { isLoading ?
+          "Loading..."
+          : (
+            <PanelSectionRow>
+              Port: { port }
+            </PanelSectionRow>
+          )
+        }
+      </PanelSection>
+    </>
   );
 };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,6 @@ import {
   PanelSectionRow,
   ServerAPI,
   staticClasses,
-  TextField,
   Navigation,
 } from "decky-frontend-lib";
 import { useContext, useEffect, useState, VFC } from "react";

--- a/src/settings.tsx
+++ b/src/settings.tsx
@@ -1,9 +1,7 @@
 import { useContext, useCallback, useEffect, useState } from 'react';
 import {
   ButtonItem,
-  DialogButton,
   TextField,
-  Navigation,
   PanelSection,
   PanelSectionRow,
 } from "decky-frontend-lib";

--- a/src/settings.tsx
+++ b/src/settings.tsx
@@ -1,0 +1,69 @@
+import { useContext, useCallback, useEffect, useState } from 'react';
+import {
+  ButtonItem,
+  DialogButton,
+  TextField,
+  Navigation,
+  PanelSection,
+  PanelSectionRow,
+} from "decky-frontend-lib";
+import { AppContext } from './utils/app-context';
+
+const Settings = () => {
+  // @ts-ignore
+  const { fileBrowserManager } = useContext( AppContext );
+  const [ port, setPort ] = useState( fileBrowserManager.getPort() );
+  const [ isSaving, setIsSaving ] = useState( false );
+  const [ isLoading, setIsLoading ] = useState( false );
+
+  const handleSave = useCallback(async () => {
+    setIsSaving( true );
+    await fileBrowserManager.setPort( port )
+    setIsSaving( false );
+  }, [port])
+
+  const handlePortChange = (e) => {
+    setPort( e.target.value );
+  }
+
+  useEffect( () => {
+    const loadDefaults = async () => {
+      const _port = await fileBrowserManager.getPortFromSettings();
+      setPort( _port );
+      console.log( _port );
+    }
+
+    setIsLoading( true );
+    loadDefaults();
+    setIsLoading( false );
+  }, [] );
+
+  return (
+    <div style={{ marginTop: "50px", color: "white" }}>
+      { isLoading ? (
+          <div style={{ textAlign: "center" }}>
+            <h2>Loading...</h2>
+          </div>
+      ) : (
+        <PanelSection title="File Browser options">
+          <PanelSectionRow>
+            <TextField
+              label="Port"
+              description="TCP port used for connection"
+              mustBeNumeric
+              onChange={ handlePortChange }
+              value={ port }
+            />
+          </PanelSectionRow>
+          <PanelSectionRow>
+            <ButtonItem onClick={ handleSave } disabled={ isSaving }>
+              Save
+            </ButtonItem>
+          </PanelSectionRow>
+        </PanelSection>
+      )}
+    </div>
+  );
+};
+
+export default Settings;

--- a/src/state/filebrowser-manager.tsx
+++ b/src/state/filebrowser-manager.tsx
@@ -1,0 +1,79 @@
+import { ServerAPI } from 'decky-frontend-lib';
+export default class FileBrowserManager {
+  private port: Number;
+  private pid: Number;
+  private ipv4_address: string;
+  private serverAPI: ServerAPI;
+
+  // @ts-ignore
+  private setServer(serv: ServerAPI): void {
+    this.serverAPI = serv;
+  }
+
+  constructor(serverAPI: ServerAPI) {
+    this.serverAPI = serverAPI;
+    this.port = 8088;
+  }
+
+  getServer(): ServerAPI {
+    return this.serverAPI;
+  }
+
+  async getUserSettings() {
+    const result = await this.serverAPI.callPluginMethod("get_user_settings", {});
+
+    if ( result.success ) {
+      return result.result;
+    } else {
+      return new Error(result.result);
+    }
+  }
+
+  getPort() {
+    return +this.port;
+  }
+
+  async getPortFromSettings() {
+    const result = await this.serverAPI.callPluginMethod("get_setting", { key: "port" });
+
+    if ( result.success ) {
+      this.port = result.result as Number;
+      return;
+    } else {
+      return new Error( result.result as string );
+    }
+  }
+
+  async setPort(port: Number) {
+    const result = await this.serverAPI.callPluginMethod("save_user_settings", { key: "port", value: port });
+
+    if ( result.success ) {
+      this.port = result.result as Number;
+      return;
+    } else {
+      return new Error( result.result as string );
+    }
+  }
+
+  async getFileBrowserStatus() {
+    const result = await this.serverAPI.callPluginMethod("getFileBrowserStatus", {});
+
+    if ( result.success ) {
+      this.port = result.result?.port as Number;
+      this.ipv4_address = result.result?.ipv4_address as string;
+      this.pid = result.result?.pid as Number;
+
+      return result.result;
+    } else {
+      return new Error( result.result );
+    }
+  }
+
+  getIPV4Address() {
+    return this.ipv4_address;
+  }
+
+  getPID() {
+    return this.pid;
+  }
+}

--- a/src/utils/app-context.tsx
+++ b/src/utils/app-context.tsx
@@ -1,0 +1,11 @@
+import { createContext } from 'react';
+
+export const AppContext = createContext({});
+
+export const AppContextProvider = ({ fileBrowserManager, children }) => {
+    return (
+        <AppContext.Provider value={{ fileBrowserManager }}>
+            {children}
+        </AppContext.Provider>
+    );
+};


### PR DESCRIPTION
### Proposed changes

Fixes #1 

- Allows users to change the port that FileBrowser listens to.
- Adds a "Settings" screen, to house different settings. ( currently only the port setting is available )
- Uses Decky's `SettingsManager` to manage persistent user settings following the [pattern defined by Decky's documentation](https://wiki.deckbrew.xyz/en/plugin-dev/getting-started#settingsmanager).
- Displays a brief summary of the current settings on the plugin's main screen.
